### PR TITLE
Support printers with "EpsonNet Config" web UI

### DIFF
--- a/epsonprinter_pkg/epsonprinterapi.py
+++ b/epsonprinter_pkg/epsonprinterapi.py
@@ -1,14 +1,25 @@
+import re
 import urllib.request
+
+from bs4 import BeautifulSoup
+
 
 class EpsonPrinterAPI(object):
     def __init__(self, ip):
         """Initialize the link to the printer status page."""
         self._resource = "http://" + ip + "/PRESENTATION/HTML/TOP/PRTINFO.HTML"
+        self._resource2 = "http://" + ip + "/status/statsupl.asp"
+        self._available_resource = None
         self.data = None
         self.available = True
         self.update()
 
     def getSensorValue(self, sensor):
+        if self._available_resource == self._resource2:
+            return self._getSensorValueStatSupl(sensor)
+        return self._getSensorValuePrtInfo(sensor)
+
+    def _getSensorValuePrtInfo(self, sensor):
         """To make it the user easier to configre the cartridge type."""
         sensorCorrected = "";
         #_LOGGER.debug("Color to fetch: " + sensor)
@@ -36,12 +47,45 @@ class EpsonPrinterAPI(object):
             #_LOGGER.error("Unable to fetch level from data: " + str(e))
             return 0
 
+    def _getSensorValueStatSupl(self, sensor):
+        """To make it the user easier to configre the cartridge type."""
+        sensorCorrected = "";
+        #_LOGGER.debug("Color to fetch: " + sensor)
+        if sensor == "black":
+            sensorCorrected = "bk"
+        # TODO others?
+        else:
+            return 0
+
+        try:
+            img = self.data.find(lambda tag: tag.name == "img" and tag.has_attr("src") and bool(re.search(r"/%s\d+.png" % re.escape(sensorCorrected), tag["src"])))
+            return int(img.next_sibling.string.strip().strip("%"))
+        except Exception as e:
+            #_LOGGER.error("Unable to fetch level from data: " + str(e))
+            return 0
+
     def update(self):
+        if self._resource:
+            self._update(self._resource)
+            if self.available:
+                self._resource2 = None
+                return
+        if self._resource2:
+            self._update(self._resource2, parse=True)
+            if self.available:
+                self._resource = None
+
+    def _update(self, resource, parse=False):
         try:
             """Just fetch the HTML page."""
-            response = urllib.request.urlopen(self._resource)
-            self.data = response.read().decode("utf-8")
+            response = urllib.request.urlopen(resource)
+            data = response.read().decode("utf-8")
             self.available = True
+            if parse:
+                self.data = BeautifulSoup(data, "html.parser")
+            else:
+                self.data = data
+            self._available_resource = resource
         except Exception as e:
             #_LOGGER.error("Unable to fetch data from your printer: " + str(e))
             self.available = False

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/thastealth/epsonprinter",
     packages=setuptools.find_packages(),
+    install_requires=["beautifulsoup4"],
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
This adds support for printers using "EpsonNet Config" web UI, such as AL-M200DN.

Implementation is far from pretty, but appears to work (black only, dunno how other colors might be represented). And it should not break other devices.

Sample HTML dump:
[statsupl.asp.txt](https://github.com/ThaStealth/epsonprinter-api/files/5179370/statsupl.asp.txt)

Partial screenshot:
![Screenshot from 2020-09-06 11-12-20](https://user-images.githubusercontent.com/109152/92322864-a7138600-f03c-11ea-8047-2e03eb6421a9.png)
